### PR TITLE
Fix Invalid Console Handle

### DIFF
--- a/.github/workflows/dev-build-windows.yml
+++ b/.github/workflows/dev-build-windows.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
     - dev
-    - "feature/fix-invalid-handle-windows"
   pull_request:
     branches: 
     - dev

--- a/.github/workflows/dev-build-windows.yml
+++ b/.github/workflows/dev-build-windows.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
     - dev
+  pull_request:
+    branches: 
+    - dev
 
 jobs:
   build:

--- a/.github/workflows/dev-build-windows.yml
+++ b/.github/workflows/dev-build-windows.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
     - dev
+    - "feature/fix-invalid-handle-windows"
   pull_request:
     branches: 
     - dev

--- a/.github/workflows/dev-build-windows.yml
+++ b/.github/workflows/dev-build-windows.yml
@@ -1,0 +1,34 @@
+name: Dev build
+
+on:
+  push:
+    branches:
+    - dev
+
+jobs:
+  build:
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        dotnet-version: ["7.0.x"]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup .NET Code SDK ${{ matrix.dotnet-version }}
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: ${{ matrix.dotnet-version }}
+    - name: Install dependencies
+      run: dotnet restore
+    - name: Build package sources
+      run: dotnet build -c Release --no-restore
+    - name: Build samples
+      run: dotnet build ./examples/solution.sln
+    - name: Test
+      run: dotnet test --no-restore --collect:"XPlat Code Coverage"
+    - name: Publish code coverage
+      uses: codecov/codecov-action@v1
+      with:
+        files: "**/coverage.cobertura.xml"
+        flags: unittests
+        name: vertical-spectreconsolelogger-codecov

--- a/.github/workflows/dev-build-windows.yml
+++ b/.github/workflows/dev-build-windows.yml
@@ -1,4 +1,4 @@
-name: Dev build
+name: Dev build - Windows
 
 on:
   push:

--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
     - dev
+  pull_request:
+    branches: 
+    - dev
 
 jobs:
   build:

--- a/src/Output/ConsoleWriter.cs
+++ b/src/Output/ConsoleWriter.cs
@@ -41,7 +41,10 @@ namespace Vertical.SpectreLogger.Output
         /// </summary>
         protected void ResetLineCore()
         {
-            AnsiConsole.Cursor.Move(CursorDirection.Left, Console.CursorLeft);
+            if (!Console.IsOutputRedirected)
+            {
+                AnsiConsole.Cursor.Move(CursorDirection.Left, Console.CursorLeft);
+            }
         }
     }
 }

--- a/test/Output/ActualConsoleWriterTests.cs
+++ b/test/Output/ActualConsoleWriterTests.cs
@@ -1,0 +1,51 @@
+﻿using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Spectre.Console;
+using Spectre.Console.Rendering;
+using Vertical.SpectreLogger.Output;
+using Xunit;
+
+namespace Vertical.SpectreLogger.Tests.Output
+{
+    public class ActualConsoleWriterTests
+    {
+        [Fact]
+        public async Task WriteInBackground()
+        {
+            var services = new ServiceCollection()
+                .AddLogging(builder => builder.AddSpectreConsole(
+                    config =>
+                    {
+                        config.WriteInBackground();
+                    }))
+                .BuildServiceProvider();
+
+            var logger = services.GetRequiredService<ILogger<ActualConsoleWriterTests>>();
+            
+            logger.LogInformation("Test event successful");
+
+            await services.DisposeAsync();
+        }
+        
+        [Fact]
+        public async Task WriteInForeground()
+        {
+            var services = new ServiceCollection()
+                .AddLogging(builder => builder.AddSpectreConsole(
+                    config =>
+                    {
+                        config.WriteInForeground();
+                    }))
+                .BuildServiceProvider();
+
+            var logger = services.GetRequiredService<ILogger<ActualConsoleWriterTests>>();
+            
+            logger.LogInformation("Test event successful");
+
+            await services.DisposeAsync();
+        }
+    }
+}

--- a/test/Output/ActualConsoleWriterTests.cs
+++ b/test/Output/ActualConsoleWriterTests.cs
@@ -1,11 +1,7 @@
-﻿using System.Text;
+﻿using System;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using NSubstitute;
-using Spectre.Console;
-using Spectre.Console.Rendering;
-using Vertical.SpectreLogger.Output;
 using Xunit;
 
 namespace Vertical.SpectreLogger.Tests.Output
@@ -44,6 +40,42 @@ namespace Vertical.SpectreLogger.Tests.Output
             var logger = services.GetRequiredService<ILogger<ActualConsoleWriterTests>>();
             
             logger.LogInformation("Test event successful");
+
+            await services.DisposeAsync();
+        }
+        
+        [Fact]
+        public async Task WriteErrorInBackground()
+        {
+            var services = new ServiceCollection()
+                .AddLogging(builder => builder.AddSpectreConsole(
+                    config =>
+                    {
+                        config.WriteInBackground();
+                    }))
+                .BuildServiceProvider();
+
+            var logger = services.GetRequiredService<ILogger<ActualConsoleWriterTests>>();
+
+            logger.LogError(new ArgumentException(), "Oops");
+
+            await services.DisposeAsync();
+        }
+        
+        [Fact]
+        public async Task WriteErrorInForeground()
+        {
+            var services = new ServiceCollection()
+                .AddLogging(builder => builder.AddSpectreConsole(
+                    config =>
+                    {
+                        config.WriteInForeground();
+                    }))
+                .BuildServiceProvider();
+
+            var logger = services.GetRequiredService<ILogger<ActualConsoleWriterTests>>();
+            
+            logger.LogError(new ArgumentException(), "Oops");
 
             await services.DisposeAsync();
         }


### PR DESCRIPTION
In some consoles, the output is redirected.

There's a call to `ResetLineCore` which moves the Console cursor, but this won't work on a redirected console.

A simple check around it to see if the console has been redirected fixes this, otherwise it throws an error.

I've added some tests, and I've also added a Windows agent github action dev build, as that's where I was seeing my issue.

Thanks