### PR TITLE
Avoid duplicate blankspace when logging with Critical

### DIFF
--- a/src/Options/SpectreLoggingBuilder.Defaults.cs
+++ b/src/Options/SpectreLoggingBuilder.Defaults.cs
@@ -123,7 +123,7 @@ namespace Vertical.SpectreLogger.Options
             
             ConfigureProfile(LogLevel.Critical, profile =>
             {
-                profile.OutputTemplate = "[[[red1]{DateTime:T}[/] [white on red1]Crit[/]]] [red3] {Message}{NewLine}{Exception}[/]";
+                profile.OutputTemplate = "[[[red1]{DateTime:T}[/] [white on red1]Crit[/]]][red3] {Message}{NewLine}{Exception}[/]";
                 profile
                     .AddTypeStyle(Types.Numerics, Color.Magenta3_2)
                     .AddTypeStyle(Types.Characters, Color.Gold3_1)


### PR DESCRIPTION
Avoid the duplicate blankspace when logging Critical messages with the defaults profiles.

![image](https://github.com/verticalsoftware/vertical-spectreconsolelogger/assets/959409/6df44279-5bca-489d-a766-55721c3c1e5f)
